### PR TITLE
[RFR] Changed the way of importing styles to be more accurate

### DIFF
--- a/iframify.js
+++ b/iframify.js
@@ -68,12 +68,12 @@
 
     if (!('srcdoc' in iframe)) {
       console.log(
-        'Your browser does not support the `srcdoc` attribute on <iframe>.' +
-        'Therefore, it is not possible to wrap node in an iframe because of' +
-        ' CORS policy. :('
+        'Your browser does not support the `srcdoc` attribute on elements.' +
+        'Therefore, it is not possible to wrap this node with an iframe due' +
+        'to CORS policy.'
       )
 
-      return false;
+      return null;
     }
 
     node.parentNode.replaceChild(iframe, node);

--- a/iframify.js
+++ b/iframify.js
@@ -16,93 +16,10 @@
  */
 
 (function (global) {
-  function assign (target, source) {
-    if (Object.assign) {
-      return Object.assign.apply(null, arguments);
-    }
-
-    var from;
-    var to = Object(target);
-
-    for (var s = 1; s < arguments.length; s++) {
-      from = Object(arguments[s]);
-
-      for (var key in from) {
-        if (hasOwnProperty.call(from, key)) to[key] = from[key];
-      }
-    }
-
-    return to;
-  }
-
-  function matches (node, selector) {
-    var fn = (node.matches || node.msMatchesSelector);
-    return fn.call(node, selector);
-  }
-
-  /**
-   * Check whether a CSS rule matters in regard to a node.
-   *
-   * @param {Node} node
-   * @param {CSSStyleDeclaration} cssRule
-   * @return {Boolean}
-   */
-  function shouldAddRule (node, cssRule) {
-    if (cssRule.cssRules) { // @media rule
-      for (var k = 0; k < cssRule.cssRules.length; k += 1) {
-        if (matches(node, cssRule.cssRules[k].selectorText)) {
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    return node.matches(cssRule.selectorText);
-  }
-
-  /**
-   * Get all the rules impacting a node as an object where the keys are the
-   * rules, and the values are always `true`. Storing in an object instead of
-   * a string or an array makes it possible to prevent duplicated rules without
-   * having too much of a performance hit.
-   *
-   * @param  {Node} node
-   * @return {Object} - Keys are rules, values are `true`
-   */
-  function getRulesImpactingNode (node) {
-    var stylesheets = document.styleSheets;
-    var object = {};
-
-    for (var i = 0; i < stylesheets.length; i += 1) {
-      var cssRules = stylesheets[i].cssRules || stylesheets[i].rules;
-      if (!cssRules) continue;
-
-      for (var j = 0; j < cssRules.length; j += 1) {
-        if (shouldAddRule(node, cssRules[j])) {
-          object[cssRules[j].cssText] = true;
-        }
-      }
-    }
-
-    return object;
-  }
-
-  /**
-   * Get string representation of all the styles relevant to a root node and all
-   * its children.
-   *
-   * @param  {Node} rootNode
-   * @return {String}
-   */
-  function getStylesForTree (rootNode) {
-    var children = rootNode.querySelectorAll('*');
-    var rules = Array.prototype.reduce.call(children, function (tree, child) {
-      return assign({}, tree, getRulesImpactingNode(child));
-    }, getRulesImpactingNode(rootNode));
-
-    return Object.keys(rules).join('');
-  }
+  var stylesheets = Array.prototype.map.call(
+    document.querySelectorAll('link[rel*=stylesheet], style'),
+    function (stylesheet) { return stylesheet.outerHTML; }
+  ).join('');
 
   /**
    * Get the content for the iframified version of a node.
@@ -113,8 +30,7 @@
   function getIframeContentForNode (node, extraCSS) {
     return '<!doctype html>' +
       '<html lang="en">' +
-      '<head>' +
-      '<style>' + getStylesForTree(node) + '</style>' +
+      '<head>' + stylesheets +
       (extraCSS ? '<style>' + extraCSS + '</style>' : '') +
       '</head>' +
       '<body>' + node.innerHTML + '</body>' +
@@ -149,19 +65,25 @@
     var iframe = document.createElement('iframe');
     var html = getIframeContentForNode(node, extraCSS);
     iframe.srcdoc = html;
-    iframe.src = 'data:text/html;charset=utf-8,' + encodeURI(html);
+
+    if (!('srcdoc' in iframe)) {
+      console.log(
+        'Your browser does not support the `srcdoc` attribute on <iframe>.' +
+        'Therefore, it is not possible to wrap node in an iframe because of' +
+        ' CORS policy. :('
+      )
+
+      return false;
+    }
+
     node.parentNode.replaceChild(iframe, node);
 
-    // If `srcdoc` is supported, there is no CORS issue therefore we can
-    // dynamically resize iframe height. The setTimeout is there to make sure
-    // that any asynchronously loaded content inside the component has been
-    // safely loaded before computing the height.
-    if ('srcdoc' in iframe) {
-      setTimeout(function () {
-        var iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
-        iframe.height = getDocumentHeight(iframeDocument);
-      }, 500);
-    }
+    setTimeout(function () {
+      var iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
+      iframe.height = getDocumentHeight(iframeDocument);
+    }, 500);
+
+    return iframe;
   }
 
   global.iframify = iframify;


### PR DESCRIPTION
I have been thinking and realised that importing styles matching the node and any of its children is not enough. A lot of styles are being inherited, therefore basically the whole parent tree would have to be analysed. In the end, it’s simpler to import all the current stylesheets regardless of whether or not they are being useful for the iframe. Visual accuracy trumps performance here.

This implementation fetches all stylesheets and style tags on load, create a DOM string out of their outerHTML, and then each iframe simply injects this string inside its head. Because of `srcdoc`, there is no CORS restriction and requests to the external stylesheets are being performed from within the iframes. Also, they are likely just be hitting the browser cache.

The bad news is that we definitely discard any browser without `srcdoc` support (IE and Edge basically). The good news is that the screen is much simpler and visually mure more accurate. Only performance to actually try, but that should be pretty okay.

PS: this PR also solves #3.

Ping @edenspiekermann/js for review.
